### PR TITLE
cleanup and simplify api

### DIFF
--- a/src/create-action.js
+++ b/src/create-action.js
@@ -1,10 +1,20 @@
-function createAction(type, payload, error, meta) {
-  return {
-    type,
-    payload,
-    error: Boolean(error),
-    meta: meta || {}
+function createAction(...args) {
+  const [type, payload, meta] = args;
+  const action = { type };
+
+  if (args.length > 1) {
+    if (payload instanceof Error) {
+      action.error = true;
+    }
+
+    action.payload = payload;
   }
+
+  if (args.length > 2) {
+    action.meta = meta;
+  }
+
+  return action;
 }
 
-module.exports = createAction;
+export default createAction;

--- a/src/create-async-action.js
+++ b/src/create-async-action.js
@@ -14,4 +14,4 @@ function createAsyncAction(type, promise) {
   };
 }
 
-module.exports = createAsyncAction;
+export default createAsyncAction;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,2 @@
-const createAction = require('./create-action');
-const createAsyncAction = require('./create-async-action');
-
-module.exports = {
-  createAction,
-  createAsyncAction
-};
+export { default as createAction } from './create-action';
+export { default as createAsyncAction } from './create-async-action';

--- a/test/create-action.js
+++ b/test/create-action.js
@@ -2,16 +2,16 @@ const {assert} = require('chai');
 const createAction = require('../src/create-action');
 
 describe('createAction', () => {
-  it('should return object contains type', () => {
+  it('should return an object with a type', () => {
     const type = 'ADD_TODO';
     const action = createAction(type);
 
     assert.isObject(action);
     assert.equal(type, action.type);
-    assert.isUndefined(action.payload);
+    assert.deepEqual(Object.keys(action), ['type']);
   });
 
-  it('should return object with type and payload', () => {
+  it('should return an object with a type and payload', () => {
     const type = 'ADD_TODO';
     const payload = 'Learn React.js';
     const action = createAction(type, payload);
@@ -19,32 +19,27 @@ describe('createAction', () => {
     assert.isObject(action);
     assert.equal(type, action.type);
     assert.equal(payload, action.payload);
+    assert.deepEqual(Object.keys(action), ['type', 'payload']);
   });
 
-  it('should return object with boolean error', () => {
+  it('should return an object with an error flag', () => {
     const type = 'ADD_TODO';
     const payload = new Error();
-    const action = createAction(type, payload, true);
+    const action = createAction(type, payload);
 
     assert.isObject(action);
     assert.equal(type, action.type);
     assert.equal(payload, action.payload);
     assert.isTrue(action.error);
+    assert.deepEqual(Object.keys(action), ['type', 'error', 'payload']);
   });
 
-  it('should return object with meta object', () => {
-    const action = createAction('ADD_TODO');
-
-    assert.isObject(action);
-    assert.isObject(action.meta);
-    assert.lengthOf(Object.keys(action.meta), 0);
-  });
-
-  it('should return object with replaced meta object', () => {
+  it('should return an object with some meta', () => {
     const meta = {pending: true};
-    const action = createAction('ADD_TODO', undefined, false, meta);
+    const action = createAction('ADD_TODO', undefined, meta);
 
     assert.isObject(action);
     assert.deepEqual(action.meta, meta);
+    assert.deepEqual(Object.keys(action), ['type', 'payload', 'meta']);
   });
 });


### PR DESCRIPTION
Hey there!

Here are the changes involved by this PR:
- I cleaned up the imports/exports to use ES6 modules as the rest of the code is ES6 (it also ends up being a little more concise).
- Create action is now smart enough to deduce whether the action is an error or not (no need for an extra error argument).
- createAction's design is focused on creating only what's necessary. So if there's no payload and/or no meta provided, there's no payload nor meta property in the action. It has two benefits: it respects the developer's intention and make it easier to spot errors. For example, if you rely on some meta but it's not provided, it's going to throw an error (until now it would fail more or less silently as there were a default value).
